### PR TITLE
Add optional Firebase (Firestore) persistence and realtime sessions

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,10 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "auth": {
+      "port": 9099
+    }
+  }
+}

--- a/firebase.rules
+++ b/firebase.rules
@@ -1,0 +1,24 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    match /sessions/{sessionId} {
+      allow read: if request.auth != null;
+      allow create: if request.auth != null && request.resource.data.keys().hasAll(["id","facilitatorUid","facilitatorName","status"]);
+      allow update: if request.auth != null && (
+        // facilitator can update any field
+        request.auth.uid == resource.data.facilitatorUid ||
+        // participants may only update safe fields on their participant doc
+        false
+      );
+      allow delete: if request.auth != null && request.auth.uid == resource.data.facilitatorUid;
+
+      match /participants/{participantId} {
+        allow read: if request.auth != null;
+        allow create: if request.auth != null && request.auth.uid == participantId;
+        allow update: if request.auth != null && request.auth.uid == participantId;
+        allow delete: if request.auth != null && (request.auth.uid == resource.data.id || request.auth.uid == get(/databases/$(database)/documents/sessions/$(sessionId)).data.facilitatorUid);
+      }
+    }
+  }
+}

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -1,0 +1,190 @@
+/* firebase.js — Helper minimal pour Firestore + Auth
+ * Usage:
+ *  - Set window.FIREBASE_CONFIG = { apiKey, authDomain, projectId, ... } in index.html before loading app.js
+ *  - Then session.js will detect fb.isEnabled() and use Firestore for persistence and realtime listeners
+ *
+ * Notes:
+ *  - Do NOT commit production API keys/secrets. Client Firebase config is public by design; secure rules control access.
+ *  - This is a minimal example, intended to be adapted for production: add stronger validation, error handling and cleanup.
+ */
+
+/* eslint-disable no-console */
+
+export let _enabled = false;
+export let _app = null;
+export let _auth = null;
+export let _db = null;
+
+// lazy init to avoid errors if FIREBASE_CONFIG is absent
+export function isEnabled() {
+    return Boolean(window.FIREBASE_CONFIG);
+}
+
+export async function ensureInit() {
+    if (!isEnabled()) return false;
+    if (_app) return true;
+
+    // Import modular Firebase SDK from CDN (works in module contexts)
+    const [{ initializeApp }, { getAuth, signInAnonymously, onAuthStateChanged, connectAuthEmulator }, { getFirestore, connectFirestoreEmulator, doc, setDoc, getDoc, updateDoc, deleteDoc, collection, onSnapshot, runTransaction, serverTimestamp, query, getDocs }] = await Promise.all([
+        import('https://www.gstatic.com/firebasejs/9.22.2/firebase-app.js'),
+        import('https://www.gstatic.com/firebasejs/9.22.2/firebase-auth.js'),
+        import('https://www.gstatic.com/firebasejs/9.22.2/firebase-firestore.js'),
+    ]);
+
+    _app = initializeApp(window.FIREBASE_CONFIG);
+    _auth = getAuth(_app);
+    _db = getFirestore(_app);
+
+    // If running with local emulators, connect to them when requested
+    if (window.FIREBASE_EMULATOR) {
+        try {
+            const authEmuUrl = window.FIREBASE_EMULATOR_AUTH_URL || 'http://localhost:9099';
+            const fsHost = window.FIREBASE_EMULATOR_FIRESTORE_HOST || 'localhost';
+            const fsPort = window.FIREBASE_EMULATOR_FIRESTORE_PORT || 8080;
+            if (typeof connectAuthEmulator === 'function') connectAuthEmulator(_auth, authEmuUrl);
+            if (typeof connectFirestoreEmulator === 'function') connectFirestoreEmulator(_db, fsHost, fsPort);
+            console.log('[firebase] connected to emulators');
+        } catch (e) {
+            console.warn('[firebase] connect emulators failed', e);
+        }
+    }
+
+    _enabled = true;
+
+    // Sign in anonymously for quick start
+    try {
+        await signInAnonymously(_auth);
+    } catch (e) {
+        // if already signed-in or blocked, ignore here — callers should handle errors
+        console.warn('[firebase] anonymous sign-in failed', e);
+    }
+
+    return true;
+}
+
+export function getAuthUid() {
+    return _auth?.currentUser?.uid ?? null;
+}
+
+// Create a session document and a participant subdoc for facilitator
+export async function createSessionFirestore(sessionId, facilitatorUid, facilitatorName, item = '') {
+    await ensureInit();
+    const sessionRef = doc(_db, 'sessions', sessionId);
+    await setDoc(sessionRef, {
+        id: sessionId,
+        facilitatorUid,
+        facilitatorName,
+        status: 'waiting',
+        currentItem: item || '',
+        createdAt: serverTimestamp(),
+    });
+
+    const pRef = doc(sessionRef, 'participants', facilitatorUid);
+    await setDoc(pRef, {
+        id: facilitatorUid,
+        name: facilitatorName,
+        vote: null,
+        isFacilitator: true,
+        joinedAt: serverTimestamp(),
+    });
+
+    return sessionRef;
+}
+
+// Add participant within a transaction to allow counting and max participants checks
+export async function addParticipant(sessionId, uid, name, maxParticipants = 8) {
+    await ensureInit();
+    const sessionRef = doc(_db, 'sessions', sessionId);
+
+    return runTransaction(_db, async (tx) => {
+        const s = await tx.get(sessionRef);
+        if (!s.exists()) throw { code: 'SESSION_NOT_FOUND' };
+
+        // count participants by reading subcollection snapshot (note: this is simple but not the most efficient for large rooms)
+        const partsSnap = await getDocs(collection(sessionRef, 'participants'));
+        const nonFac = partsSnap.docs.filter(d => !(d.data().isFacilitator));
+        if (nonFac.length >= maxParticipants) throw { code: 'SESSION_FULL' };
+
+        const pRef = doc(sessionRef, 'participants', uid);
+        tx.set(pRef, { id: uid, name, vote: null, isFacilitator: false, joinedAt: serverTimestamp() });
+    });
+}
+
+// Listen for session doc + participants subcollection and call onUpdate with a combined session object
+export async function listenSession(sessionId, onUpdate, onError) {
+    await ensureInit();
+    const sessionRef = doc(_db, 'sessions', sessionId);
+
+    let lastSession = null;
+    let lastParticipants = [];
+    
+    const unsubSession = onSnapshot(sessionRef, (snap) => {
+        if (!snap.exists()) {
+            onError && onError({ code: 'SESSION_NOT_FOUND' });
+            return;
+        }
+        lastSession = snap.data();
+        // combine and call
+        onUpdate && onUpdate(combine(lastSession, lastParticipants));
+    }, (err) => onError && onError(err));
+
+    const partsCol = collection(sessionRef, 'participants');
+    const unsubParts = onSnapshot(partsCol, (qSnap) => {
+        lastParticipants = qSnap.docs.map(d => d.data());
+        onUpdate && onUpdate(combine(lastSession, lastParticipants));
+    }, (err) => onError && onError(err));
+
+    function combine(sessionDoc, participantsArr) {
+        if (!sessionDoc) return null;
+        return {
+            id: sessionDoc.id,
+            facilitatorId: sessionDoc.facilitatorUid,
+            facilitatorName: sessionDoc.facilitatorName,
+            status: sessionDoc.status,
+            currentItem: sessionDoc.currentItem || '',
+            participants: participantsArr || [],
+            createdAt: sessionDoc.createdAt ? sessionDoc.createdAt.seconds * 1000 : Date.now(),
+        };
+    }
+
+    return function unsubscribe() {
+        try { unsubSession(); } catch (e) {}
+        try { unsubParts(); } catch (e) {}
+    };
+}
+
+export async function castVoteFirestore(sessionId, uid, vote) {
+    await ensureInit();
+    const pRef = doc(_db, 'sessions', sessionId, 'participants', uid);
+    await updateDoc(pRef, { vote });
+}
+
+export async function updateSessionFirestore(sessionId, patch = {}) {
+    await ensureInit();
+    const sessionRef = doc(_db, 'sessions', sessionId);
+    await updateDoc(sessionRef, { ...patch, updatedAt: serverTimestamp() });
+}
+
+export async function removeParticipant(sessionId, uid) {
+    await ensureInit();
+    const pRef = doc(_db, 'sessions', sessionId, 'participants', uid);
+    try { await deleteDoc(pRef); } catch (e) { console.warn('[firebase] removeParticipant', e); }
+}
+
+export async function closeSessionFirestore(sessionId) {
+    await ensureInit();
+    const sessionRef = doc(_db, 'sessions', sessionId);
+    // Best effort: mark closedAt; deletion of subcollections requires batch deletes or Cloud Function
+    await updateDoc(sessionRef, { closedAt: serverTimestamp() }).catch(async (e) => {
+        // If update fails because doc doesn't exist, ignore
+        try { await deleteDoc(sessionRef); } catch (err) { console.warn('[firebase] closeSession', err); }
+    });
+}
+
+// Utility: simple helper to surface errors with code mapping
+export function mapError(e) {
+    if (!e) return { code: 'UNKNOWN', message: 'Erreur inconnue' };
+    if (e.code) return e;
+    if (e.message) return { code: 'ERROR', message: e.message };
+    return { code: 'ERROR' };
+}

--- a/js/session.js
+++ b/js/session.js
@@ -17,6 +17,7 @@
 
 import {ROLE, STATUS} from './config.js';
 import {clearMe, deleteSession, loadSession, saveMe, saveSession} from './storage.js';
+import * as fb from './firebase.js';
 import {
     broadcastClose,
     broadcastState,
@@ -104,6 +105,62 @@ export function buildInviteUrl() {
 export async function createSession(name, item = '', onReady, onRender) {
     if (!name) return false;
 
+    // If Firebase is configured, use Firestore as the source of truth
+    if (fb.isEnabled()) {
+        await fb.ensureInit();
+        // Use auth UID if present, otherwise generate a stable id for this tab
+        const uid = fb.getAuthUid() || _genParticipantId();
+
+        state.myId = uid;
+        state.myName = name;
+        state.myRole = ROLE.FACILITATOR;
+
+        // Generate a sessionId and create Firestore document (retry on collision)
+        let sessionId;
+        for (let i = 0; i < 5; i++) {
+            sessionId = _genSessionId(4);
+            try {
+                await fb.createSessionFirestore(sessionId, uid, name, item);
+                break;
+            } catch (e) {
+                // If the session doc already exists, retry a few times
+                if (e && e.code === 'ALREADY_EXISTS' && i < 4) continue;
+                console.error('[session][firebase] createSessionFirestore:', e);
+                return false;
+            }
+        }
+
+        state.sessionId = sessionId;
+        state.session = {
+            id: sessionId,
+            facilitatorId: state.myId,
+            facilitatorName: name,
+            status: STATUS.WAITING,
+            currentItem: item,
+            participants: [{id: state.myId, name, vote: null, isFacilitator: true}],
+            createdAt: Date.now(),
+        };
+
+        saveMe({myId: state.myId, myName: state.myName, myRole: state.myRole, sessionId});
+        setUrlSessionId(sessionId);
+
+        // Start real-time listener
+        try {
+            await fb.listenSession(sessionId, (sess) => {
+                state.session = sess;
+                onRender?.();
+            }, (err) => {
+                console.warn('[session][firebase] listenSession error', err);
+            });
+        } catch (e) {
+            console.warn('[session][firebase] listenSession setup failed', e);
+        }
+
+        onReady?.();
+        return true;
+    }
+
+    // Fallback: existing WebRTC PeerJS facilitator flow
     initWebRTC(state, onRender);
 
     // Tenter jusqu'à 5 codes différents en cas de collision
@@ -170,6 +227,35 @@ export async function joinSession(code, name, onReady, onRender) {
     state.myName = name;
     state.myRole = ROLE.PARTICIPANT;
 
+    // If Firebase is enabled, use Firestore join flow
+    if (fb.isEnabled()) {
+        try {
+            await fb.ensureInit();
+            const uid = fb.getAuthUid() || state.myId;
+            state.myId = uid;
+            await fb.addParticipant(code, uid, name);
+
+            // Start listening to session updates
+            await fb.listenSession(code, (sess) => {
+                state.session = sess;
+                onRender?.();
+            }, (err) => {
+                console.warn('[session][firebase] listenSession error', err);
+            });
+
+        } catch (e) {
+            const errCode = e && e.code ? e.code : 'PEER_ERROR';
+            return {success: false, error: errCode};
+        }
+
+        state.sessionId = code;
+        saveMe({myId: state.myId, myName: state.myName, myRole: state.myRole, sessionId: code});
+        setUrlSessionId(code);
+        onReady?.();
+        return {success: true};
+    }
+
+    // Fallback: original WebRTC join flow
     initWebRTC(state, onRender);
 
     try {
@@ -206,6 +292,33 @@ export async function joinSession(code, name, onReady, onRender) {
  * @returns {Promise<boolean>}
  */
 export async function restoreSession(me, onReady, onRender) {
+    // If Firebase is enabled, re-subscribe to the Firestore session
+    if (fb.isEnabled()) {
+        await fb.ensureInit();
+
+        state.myId = me.myId;
+        state.myName = me.myName;
+        state.myRole = me.myRole;
+        state.sessionId = me.sessionId;
+
+        try {
+            await fb.listenSession(me.sessionId, (sess) => {
+                state.session = sess;
+                onRender?.();
+            }, (err) => {
+                console.warn('[session][firebase] restore listen error', err);
+            });
+        } catch (e) {
+            console.warn('[session][firebase] restore failed', e);
+            return false;
+        }
+
+        setUrlSessionId(me.sessionId);
+        onReady?.();
+        return true;
+    }
+
+    // Default WebRTC restore logic
     initWebRTC(state, onRender);
 
     state.myId = me.myId;
@@ -328,13 +441,31 @@ export function castVote(value) {
     if (!me) return false;
 
     me.vote = value;
-    sendToFacilitator({type: 'vote_cast', pid: state.myId, vote: value});
+
+    if (fb.isEnabled()) {
+        // Persist vote in Firestore
+        fb.castVoteFirestore(state.sessionId, state.myId, value).catch(e => console.warn('[session][firebase] castVote', e));
+    } else {
+        // Default P2P transport
+        sendToFacilitator({type: 'vote_cast', pid: state.myId, vote: value});
+    }
     return true;
 }
 
 /** Quitte la session proprement. */
 export function leaveSession() {
     if (!state.session) return;
+
+    if (fb.isEnabled()) {
+        // Remove participant from Firestore and clear local state
+        fb.removeParticipant(state.sessionId, state.myId).catch(e => console.warn('[session][firebase] removeParticipant', e));
+        clearMe();
+        clearUrlSessionId();
+        state.session = null;
+        state.sessionId = null;
+        return;
+    }
+
     sendToFacilitator({type: 'participant_leave', pid: state.myId});
     disconnectWebRTC();
     clearMe();


### PR DESCRIPTION
Pourquoi

Pour fournir une option de persistance fiable et une synchronisation multi‑appareils, ce PR ajoute une intégration minimale avec Firebase (Auth anonymes + Firestore). L'objectif est de permettre un basculement simple entre le mode P2P actuel (PeerJS/WebRTC) et Firestore en source de vérité, afin d'améliorer la robustesse des sessions et la collaboration multi‑utilisateurs.

Approche générale

- Ajout d'un module js/firebase.js qui :
  - initialise Firebase (modulaire via CDN), Auth (signInAnonymously) et Firestore
  - fournit helpers : createSessionFirestore, addParticipant, listenSession (doc + participants), castVoteFirestore, removeParticipant, closeSessionFirestore
  - supporte connexion aux émulateurs via window.FIREBASE_EMULATOR
- Ajout de firebase.rules (règles de sécurité de base) et firebase.json (config émulateur)
- Adaptation de js/session.js pour :
  - utiliser Firestore quand window.FIREBASE_CONFIG est fourni (feature flag côté client)
  - conserver le comportement WebRTC/PeerJS en fallback quand Firebase n'est pas configuré
  - persister votes/participants dans Firestore et s'abonner avec onSnapshot pour mises à jour en temps réel

Changements notables

- Nouveaux fichiers :
  - js/firebase.js  (nouveau helper Firestore + Auth)
  - firebase.rules  (règles Firestore à déployer)
  - firebase.json   (config pour Firebase Emulator)
- Modifié : js/session.js — logique create/join/restore/castVote/leave maintenant supporte Firestore en option

Points d'attention / tradeoffs

- Ce patch fournit une intégration minimale (POC) — il faudra :
  - ajouter validation utilisateur (longueur/characters) côté client avant écriture
  - améliorer la gestion des erreurs UX (timeouts, messages lisibles)
  - nettoyer les sous‑collections lors de la fermeture (ex: Cloud Function pour suppression en batch)
  - décider si PeerJS est conservé (pour voix/media) ou supprimé à terme
- Firestore rules incluses sont une base ; il est fortement recommandé de tester et renforcer via Firebase Emulator Suite avant mise en production.

Comment tester localement

1. Installer Firebase CLI et lancer les émulateurs :
   firebase emulators:start --only firestore,auth
2. Dans index.html, ajouter avant le chargement de js/app.js :
   <script>
     window.FIREBASE_CONFIG = { /* config du projet d'emulateur ou config client */ };
     window.FIREBASE_EMULATOR = true;
   </script>
3. Ouvrir l'app : créer une session (le créateur sera enregistré dans Firestore), rejoindre depuis un autre onglet, voter, révéler — les changements se propagent via onSnapshot.

Checklist avant merge

- [ ] Valider firebase.rules avec Firebase Emulator Suite
- [ ] Ajouter messages d'erreur utilisateur lisibles pour les échecs réseau
- [ ] Ajouter tests d'intégration basiques (Emulator)

Fichiers modifiés / ajoutés

- Add: js/firebase.js
- Add: firebase.rules
- Add: firebase.json
- Modify: js/session.js

Co‑authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>